### PR TITLE
add flag for setting service file name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "sludge",
 	"description": "experimental live streaming server",
-	"version": "1.0.0",
+	"version": "2.0.0",
 	"main": "src/sludge.ts",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",

--- a/src/cliHelp.ts
+++ b/src/cliHelp.ts
@@ -5,32 +5,34 @@ deno run src/sludge.ts { arguments }
 
 Arguments:
 	
-	--development		Development mode for local deployment (default)
+	--development			Development mode for local deployment (default)
 	
-	--test			Test mode for generating files without running server
+	--test				Test mode for generating files without running server
 	
-	--production		Production mode for running sludge on a server
+	--production			Production mode for running sludge on a server
 	
-	--dir="<file path>"	Set directory for saving files, e.g. ~/.sludge
+	--dir="<file path>"		Set directory for saving files, e.g. ~/.sludge
 	
-	--port="<port>"		Port for running sludge app, e.g. 8080
+	--port="<port>"			Port for running sludge app, e.g. 8080
 	
-	--public="<url>"	URL for accessing sludge API, e.g. https://ga.ge/
+	--public="<url>"		URL for accessing sludge API, e.g. https://example.com/
 	
-	--files="<url>"		URL for accessing sludge audio, e.g. https://ga.ge/audio/
+	--files="<url>"			URL for accessing sludge audio, e.g. https://example.com/audio/
 
-	--configure		Generate templates for nginx and system services to run server
-				Development mode will work on Linux / OS X and only run nginx
-				Test mode will only output configuration files
-				Production mode works only on Linux and run nginx and systemd services
+	--configure			Generate templates for nginx and system services to run server
+					Development mode will work on Linux / OS X and only run nginx
+					Test mode will only output configuration files
+					Production mode works only on Linux and run nginx and systemd services
 	
-	--nginx="<port>"	Port that nginx will be exposed on, e.g. 80
+	--nginx="<port>"		Port that nginx will be exposed on, e.g. 80
 	
-	--host="<host/ip>"	Address that will be used to access nginx, e.g. ga.ge
+	--host="<host/ip>"		Address that will be used to access nginx, e.g. example.com
 	
-	--cache="<days>"	Number of days to cache audio files, e.g. 30
+	--cache="<days>"		Number of days to cache audio files, e.g. 30
 	
-	--name="<file name>"	Name of nginx configuration file, default is sludge_nginx.conf
+	--conf="<file name>"		Name of nginx configuration file, default is sludge_nginx.conf
 	
-	--help			Show this information screen
+	--service="<file name>"		Name of service file, default is sludge_server.service
+	
+	--help				Show this information screen
 `

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -107,6 +107,7 @@ export class Configure
 	 * @param rootFilePath path to where files are stored on the machine
 	 * @param cacheAgeDays length in days to preserve audio file cache
 	 * @param nginxConfFileName file name to save the nginx config file under
+	 * @param serviceFileName file name to save the systemd file under
 	 * @param filesURL URL/path where the audio files will be accessed
 	 * @param publicURL URL/path where the app will be accessed
 	 */
@@ -119,6 +120,7 @@ export class Configure
 		private rootFilePath: string,
 		cacheAgeDays: number,
 		nginxConfFileName = `sludge_nginx.conf`,
+		serviceFileName = `sludge_server.service`,
 		private filesURL?: URL,
 		private publicURL?: URL
 	)
@@ -129,7 +131,7 @@ export class Configure
 				? join( `/etc/nginx/sites-enabled`, nginxConfFileName )
 				: join( `/usr/local/etc/nginx/servers`, nginxConfFileName )
 
-		this.servicePath = `/etc/systemd/system/sludge_server.service`
+		this.servicePath = `/etc/systemd/system/${serviceFileName}`
 
 		this.segmentFileRegex = `${this.regexStr}\\.opus`
 

--- a/src/sludge.ts
+++ b/src/sludge.ts
@@ -134,7 +134,8 @@ class Sludge
 			port,
 			rootDir,
 			cache,
-			flags.name,
+			flags.conf,
+			flags.service,
 			fileURL,
 			publicURL
 		)


### PR DESCRIPTION
change flag name for nginx conf file name

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

update

* **What is the current behavior?** (You can also link to an open issue here)

pass flags to setup config

* **What is the new behavior (if this is a feature change)?**

pass extra flag to set service file name

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

yes, nginx conf flag name change

* **Other information**:
